### PR TITLE
Use squash method for merging

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -52,6 +52,7 @@ export const handleProcessCommand = async (
       owner: githubActions.context.repo.owner,
       repo: githubActions.context.repo.repo,
       pull_number: githubActions.context.issue.number,
+      merge_method: "squash",
     });
     return { success: true, message: "The on-chain referendum has approved the RFC." };
   }


### PR DESCRIPTION
The RFC repo has the merge-commit method disabled (which is the default).
The bot fails when trying to merge now.

Closes https://github.com/paritytech/rfc-action/issues/14