### PR TITLE
More graceful handling of lacking merge/close permissions

### DIFF
--- a/src/find-referendum-state.ts
+++ b/src/find-referendum-state.ts
@@ -7,10 +7,11 @@ import { ParseRFCResult } from "./parse-RFC";
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
 
 /**
- * @returns The state of the referendum, which can be:
- * - approved,
- * - rejected,
- * - null, meaning that the referendum in a proper state with a proper remark has not been found.
+ * @returns Find the state of a referendum concerning this RFC.
+ * The returned RFC referendum state can be one of:
+ * - approved (and executed) - meaning the referendum approving this RFC has passed and has been executed,
+ * - rejected (and executed) - meaning the referendum rejecting this RFC has passed and has been executed,
+ * - null, meaning that the referendum in a proper state with a proper remark has not been found. It's possible there is a referendum approving or rejecting this RFC but has not passed and not been executed yet.
  */
 export const findReferendumState = async (opts: {
   parseRFCResult: ParseRFCResult;

--- a/src/find-referendum-state.ts
+++ b/src/find-referendum-state.ts
@@ -6,11 +6,17 @@ import { ParseRFCResult } from "./parse-RFC";
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
 
-export const findReferendum = async (opts: {
+/**
+ * @returns The state of the referendum, which can be:
+ * - approved,
+ * - rejected,
+ * - null, meaning that the referendum in a proper state with a proper remark has not been found.
+ */
+export const findReferendumState = async (opts: {
   parseRFCResult: ParseRFCResult;
   blockHash: string;
   providerUrl?: string | undefined;
-}): Promise<null | { approved: boolean }> => {
+}): Promise<null | "approved" | "rejected"> => {
   const api = new ApiPromise({ provider: new WsProvider(opts.providerUrl ?? PROVIDER_URL) });
   await api.isReadyOrError;
 
@@ -37,11 +43,11 @@ export const findReferendum = async (opts: {
 
       if (remarkMatchesProposal(api.tx.system.remark(opts.parseRFCResult.approveRemarkText))) {
         await api.disconnect();
-        return { approved: true };
+        return "approved";
       }
       if (remarkMatchesProposal(api.tx.system.remark(opts.parseRFCResult.rejectRemarkText))) {
         await api.disconnect();
-        return { approved: false };
+        return "rejected";
       }
     }
   }

--- a/src/find-referendum.test.ts
+++ b/src/find-referendum.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 
-import { findReferendum } from "./find-referendum";
+import { findReferendumState } from "./find-referendum-state";
 import { getApproveRemarkText, getRejectRemarkText } from "./parse-RFC";
 
 describe("findReferendum", () => {
@@ -8,7 +8,7 @@ describe("findReferendum", () => {
     // https://collectives.polkassembly.io/member-referenda/16
     const rfcNumber = "0014";
     const text = fs.readFileSync("src/examples/0014-improve-locking-mechanism-for-parachains.md").toString();
-    const result = await findReferendum({
+    const result = await findReferendumState({
       blockHash: "0x39fbc57d047c71f553aa42824599a7686aea5c9aab4111f6b836d35d3d058162",
       parseRFCResult: {
         rfcNumber,
@@ -18,7 +18,7 @@ describe("findReferendum", () => {
       },
     });
 
-    expect(result && "approved" in result && result.approved).toBeTruthy();
+    expect(result).toEqual("approved");
   });
 
   test.skip("Finds the (inlined) 0014 referendum", async () => {
@@ -41,7 +41,7 @@ describe("findReferendum", () => {
 
     const rfcNumber = "0014";
     const text = fs.readFileSync("src/examples/0014-improve-locking-mechanism-for-parachains.md").toString();
-    const result = await findReferendum({
+    const result = await findReferendumState({
       providerUrl,
       blockHash,
       parseRFCResult: {
@@ -52,6 +52,6 @@ describe("findReferendum", () => {
       },
     });
 
-    expect(result && "approved" in result && result.approved).toBeTruthy();
+    expect(result).toEqual("approved");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export async function run(): Promise<void> {
       throw e;
     }
   } catch (error) {
+    core.error((error as Error).stack ?? String(error));
     core.setFailed(error instanceof Error ? error.message : String(error));
   }
 }

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,6 +1,6 @@
 import * as githubActions from "@actions/github";
 
-import { findReferendum } from "./find-referendum";
+import { findReferendumState } from "./find-referendum-state";
 import { parseRFC } from "./parse-RFC";
 import { RequestResult, RequestState } from "./types";
 
@@ -40,14 +40,13 @@ export const handleProcessCommand = async (
     };
   }
 
-  const referendum = await findReferendum({ parseRFCResult, blockHash });
-  if (!referendum) {
+  const referendumState = await findReferendumState({ parseRFCResult, blockHash });
+  if (!referendumState) {
     return {
       success: false,
       errorMessage: `Unable to find the referendum confirm event in the given block.\n\n` + blockHashInstructions,
     };
-  }
-  if ("approved" in referendum && referendum.approved) {
+  } else if (referendumState === "approved") {
     try {
       await requestState.octokitInstance.rest.pulls.merge({
         owner: githubActions.context.repo.owner,
@@ -64,21 +63,24 @@ export const handleProcessCommand = async (
           "The on-chain referendum has approved the RFC, however I was not able to merge the PR automatically.",
       };
     }
-  }
-  try {
-    await requestState.octokitInstance.rest.pulls.update({
-      owner: githubActions.context.repo.owner,
-      repo: githubActions.context.repo.repo,
-      pull_number: githubActions.context.issue.number,
-      state: "closed",
-    });
-    return { success: true, message: "The on-chain referendum has rejected the RFC." };
-  } catch (e) {
-    requestState.octokitInstance.log.error(String(e));
-    return {
-      success: false,
-      errorMessage:
-        "The on-chain referendum has rejected the RFC, however I was not able to merge the PR automatically.",
-    };
+  } else if (referendumState === "rejected") {
+    try {
+      await requestState.octokitInstance.rest.pulls.update({
+        owner: githubActions.context.repo.owner,
+        repo: githubActions.context.repo.repo,
+        pull_number: githubActions.context.issue.number,
+        state: "closed",
+      });
+      return { success: true, message: "The on-chain referendum has rejected the RFC." };
+    } catch (e) {
+      requestState.octokitInstance.log.error(String(e));
+      return {
+        success: false,
+        errorMessage:
+          "The on-chain referendum has rejected the RFC, however I was not able to close the PR automatically.",
+      };
+    }
+  } else {
+    throw new Error(`The referendum is in an unknown state: "${String(referendumState)}".`);
   }
 };


### PR DESCRIPTION
Instead of completely failing when lacking the merge/close permissions, it will print an appropriate comment in the PR.