### PR TITLE
Introduce a post-merge test PR

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   create-pr:
@@ -43,4 +44,4 @@ jobs:
           add-paths: |
             text/*.md
           title: "[Post-merge test] A test PR for testing the action"
-          body: "Use `/rfc process` to merge the PR and test the action after a recent push to `main`."
+          body: "@${{ github.event.pusher.name }} Use `/rfc process` to merge the PR and test the action after a recent push to `main`."

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -44,4 +44,4 @@ jobs:
           add-paths: |
             text/*.md
           title: "[Post-merge test] A test PR for testing the action"
-          body: "@${{ github.event.pusher.name }} Use `/rfc process` to merge the PR and test the action after a recent push to `main`."
+          body: "@paritytech/opstooling This is a test PR created automatically because a recent change has been merged to master.\nUse `/rfc process 0x39fbc57d047c71f553aa42824599a7686aea5c9aab4111f6b836d35d3d058162` to process the PR and test out the code on `main`."

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir text
           cp src/examples/0014-improve-locking-mechanism-for-parachains.md ./text/
 
-      - name: Create a PR to the newsletter repo
+      - name: Create a test PR
         uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5 # v5
         with:
           base: ${{ steps.generate_branches.outputs.base_branch }}

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -1,0 +1,44 @@
+name: Create a test PR after merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-pr:
+    name: Create a test PR after merge 
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # We need a fresh base branch every time,
+      # so that it doesn't contain the text that we want to merge with the PR.
+      - name: Generate branch names
+        id: generate_branches
+        run: |
+          timestamp=$(date +%Y-%m-%dT%H-%M)
+          echo "base_branch=test_base_$timestamp" >> $GITHUB_OUTPUT
+          echo "head_branch=test_head_$timestamp" >> $GITHUB_OUTPUT
+      
+      - name: Create a base branch
+        run: |
+          git checkout -b ${{ steps.generate_branches.outputs.base_branch }}
+          git push --set-upstream origin ${{ steps.generate_branches.outputs.base_branch }}
+      
+      - name: Create the changes for the PR
+        run: |
+          git checkout -b ${{ steps.generate_branches.outputs.head_branch }}
+          mkdir text
+          cp src/examples/0014-improve-locking-mechanism-for-parachains.md ./text/
+
+      - name: Create a PR to the newsletter repo
+        uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5 # v5
+        with:
+          base: ${{ steps.generate_branches.outputs.base_branch }}
+          add-paths: |
+            text/*.md
+          title: "[Post-merge test] A test PR for testing the action"
+          body: "Use `/rfc process` to merge the PR and test the action after a recent push to `main`."

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   create-pr:
     name: Create a test PR after merge 

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -32,7 +32,6 @@ jobs:
       
       - name: Create the changes for the PR
         run: |
-          git checkout -b ${{ steps.generate_branches.outputs.head_branch }}
           mkdir text
           cp src/examples/0014-improve-locking-mechanism-for-parachains.md ./text/
 

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -28,8 +28,7 @@ jobs:
       
       - name: Create a base branch
         run: |
-          git checkout -b ${{ steps.generate_branches.outputs.base_branch }}
-          git push --set-upstream origin ${{ steps.generate_branches.outputs.base_branch }}
+          git push origin HEAD:${{ steps.generate_branches.outputs.base_branch }}
       
       - name: Create the changes for the PR
         run: |
@@ -41,6 +40,7 @@ jobs:
         uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5 # v5
         with:
           base: ${{ steps.generate_branches.outputs.base_branch }}
+          branch: ${{ steps.generate_branches.outputs.head_branch }}
           add-paths: |
             text/*.md
           title: "[Post-merge test] A test PR for testing the action"

--- a/.github/workflows/rfc-action.yml
+++ b/.github/workflows/rfc-action.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   rfc-action:


### PR DESCRIPTION
Introduce a way of testing the action after a merge, using a mock PR.

Manually testing the action is tedious, so we don't always do that.

This workflow will create a PR [like this](https://github.com/rzadp/rfc-action/pull/4) so it can easily be tested.